### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides full access to Cloudeka's cldkctl CLI functionality through Claude Desktop, Cursor, and other MCP-compatible clients.
 
+<a href="https://glama.ai/mcp/servers/@raffelprama/mcp-cldkctl">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@raffelprama/mcp-cldkctl/badge" alt="cldkctl Server MCP server" />
+</a>
+
 ## Features
 
 - **Smart Authentication**: Automatic environment fallback (production -> staging)


### PR DESCRIPTION
This PR adds a badge for the [MCP cldkctl Server](https://glama.ai/mcp/servers/@raffelprama/mcp-cldkctl) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@raffelprama/mcp-cldkctl">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@raffelprama/mcp-cldkctl/badge" alt="cldkctl Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.